### PR TITLE
Implement profile picture upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ Sicherheit	• Hoher Schutz vor Web-Angriffen (CSRF, XSS, SQL-Injection u. a.).
 ⸻
 
 Ergebnis: Eine fokussierte, private Planungsplattform mit maximaler Übersicht, blitzschnellen Reaktionen und minimalem Overhead – perfekt abgestimmt auf kleine Freundeskreise.
+
+## Beispiel-Server starten
+
+Für einen lokalen Test ist eine Minimal-Implementierung in `app.py` enthalten.
+Installation der Abhängigkeiten und Start des Servers:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Die Registrierung erreicht man über `http://localhost:5000/register`. Dort kann
+bereits ein Profilbild hochgeladen werden. Die Bilder werden im Ordner
+`user-assets/<userid>/profile.jpg` gespeichert und auf 512×512 Pixel reduziert.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,67 @@
+import os
+from flask import Flask, request, redirect, url_for, render_template, send_from_directory
+from werkzeug.utils import secure_filename
+from PIL import Image
+
+app = Flask(__name__)
+app.config['MAX_CONTENT_LENGTH'] = 1 * 1024 * 1024  # 1 MB upload limit
+app.config['UPLOAD_FOLDER'] = os.path.join(os.getcwd(), 'user-assets')
+ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg'}
+
+# Simple in-memory user store
+USERS = {}
+
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        file = request.files.get('profile_pic')
+
+        if not username or not password or not file:
+            return render_template('register.html', error='Alle Felder sind erforderlich.')
+        if not allowed_file(file.filename):
+            return render_template('register.html', error='Nur JPEG und PNG sind erlaubt.')
+        filename = secure_filename(file.filename)
+        ext = filename.rsplit('.', 1)[1].lower()
+
+        user_id = str(len(USERS) + 1)
+        user_dir = os.path.join(app.config['UPLOAD_FOLDER'], user_id)
+        os.makedirs(user_dir, exist_ok=True)
+        image_path = os.path.join(user_dir, 'profile.jpg')
+
+        try:
+            img = Image.open(file.stream)
+            img = img.convert('RGB')
+            img.thumbnail((512, 512))
+            img.save(image_path, format='JPEG')
+        except Exception:
+            return render_template('register.html', error='Fehler beim Verarbeiten des Bildes.')
+
+        USERS[user_id] = {'username': username, 'password': password}
+        return redirect(url_for('profile', user_id=user_id))
+
+    return render_template('register.html')
+
+
+@app.route('/profile/<user_id>')
+def profile(user_id):
+    user = USERS.get(user_id)
+    if not user:
+        return 'Unbekannter Nutzer', 404
+    return render_template('profile.html', user=user, user_id=user_id)
+
+
+@app.route('/user-assets/<user_id>/profile.jpg')
+def profile_pic(user_id):
+    return send_from_directory(os.path.join(app.config['UPLOAD_FOLDER'], user_id), 'profile.jpg')
+
+
+if __name__ == '__main__':
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Pillow

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,6 @@
+.profile {
+    width: 128px;
+    height: 128px;
+    border-radius: 50%;
+    object-fit: cover;
+}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Profil</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Willkommen, {{ user.username }}</h1>
+    <img src="{{ url_for('profile_pic', user_id=user_id) }}" class="profile" alt="Profilbild">
+</body>
+</html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Registrierung</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Registrierung</h1>
+    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+    <form method="post" enctype="multipart/form-data">
+        <label>Nutzername: <input type="text" name="username"></label><br>
+        <label>Passwort: <input type="password" name="password"></label><br>
+        <label>Profilbild: <input type="file" name="profile_pic" accept="image/*"></label><br>
+        <button type="submit">Registrieren</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement basic Flask server with profile picture upload on registration
- store images under `user-assets/<userid>/profile.jpg`
- render profile images as circles
- add minimal example instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a521edcd48333a09c6d0af0d32322