### PR TITLE
Implement responsive base layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ActivityPlanner</title>
+    <style>body{visibility:hidden}</style>
+    <link rel="preload" href="styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="styles.css"></noscript>
+</head>
+<body>
+    <header class="toolbar">
+        <button class="action-button">Kommt her</button>
+        <div class="profile">
+            <span id="ready-indicator" class="ready"></span>
+            <img src="profile.jpg" alt="Profil" class="profile-image" />
+        </div>
+    </header>
+    <main class="content">
+        <div class="card-grid">
+            <div class="card">Beispielinhalt 1</div>
+            <div class="card">Beispielinhalt 2</div>
+            <div class="card">Beispielinhalt 3</div>
+        </div>
+    </main>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,7 @@
+// Toggle ready status indicator for demonstration
+let ready = true;
+const indicator = document.getElementById('ready-indicator');
+setInterval(() => {
+    ready = !ready;
+    indicator.style.background = ready ? 'var(--color-green)' : 'var(--color-red)';
+}, 2000);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,92 @@
+:root {
+    --color-green: #2ECC71;
+    --color-red: #E74C3C;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    visibility: visible;
+    font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background: #fff;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.action-button {
+    background: var(--color-green);
+    border: none;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.action-button:hover {
+    transform: scale(1.05);
+}
+
+.profile {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.profile-image {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+}
+
+#ready-indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--color-green);
+    animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.3); opacity: 0.7; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+.content {
+    flex: 1;
+    padding: 1rem;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    background: #f8f8f8;
+    padding: 1rem;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+@media (max-width: 600px) {
+    .toolbar {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple responsive skeleton using flexbox and grid
- prepare green/red color palette in CSS variables
- include toolbar with `Kommt her` button and profile area
- add JS demo toggle for the ready indicator

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a523b57288333a238ecaa7614f1d3