### PR TITLE
Implement rejected list with recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ Sicherheit	• Hoher Schutz vor Web-Angriffen (CSRF, XSS, SQL-Injection u. a.).
 ⸻
 
 Ergebnis: Eine fokussierte, private Planungsplattform mit maximaler Übersicht, blitzschnellen Reaktionen und minimalem Overhead – perfekt abgestimmt auf kleine Freundeskreise.
+
+⸻
+
+## Quickstart
+
+Dieses Repository enthält eine minimale Beispiel-Implementierung. Die Web-App lässt sich lokal starten, indem man die Datei `public/index.html` in einem Browser öffnet oder einen einfachen HTTP-Server im `public`-Verzeichnis startet:
+
+```bash
+# Beispiel mit Python
+cd public
+python3 -m http.server
+```
+
+Danach ist die Anwendung unter `http://localhost:8000` erreichbar.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>ActivityPlanner</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="profile-menu">
+            <img src="https://via.placeholder.com/40" alt="Profil" class="profile-pic" id="profilePic">
+            <div class="dropdown" id="profileDropdown">
+                <button id="dropdownButton">▼</button>
+                <ul id="dropdownList" class="hidden">
+                    <li id="rejectedMenu">Abgelehnt</li>
+                </ul>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section id="carousel"></section>
+        <section id="rejectedSection" class="hidden">
+            <h2>Abgelehnte Aktivitäten</h2>
+            <div id="rejectedList"></div>
+        </section>
+    </main>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,71 @@
+const activities = [
+    { id: 1, title: 'Wandern', date: '2024-05-01', image: 'https://via.placeholder.com/150', status: 'none' },
+    { id: 2, title: 'Kinoabend', date: '2024-05-03', image: 'https://via.placeholder.com/150', status: 'none' },
+    { id: 3, title: 'Grillen', date: '2024-05-05', image: 'https://via.placeholder.com/150', status: 'none' }
+];
+
+function renderCarousel() {
+    const carousel = document.getElementById('carousel');
+    carousel.innerHTML = '';
+    activities.filter(a => a.status !== 'rejected').forEach(activity => {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `
+            <h3>${activity.title}</h3>
+            <small>${activity.date}</small>
+            <img src="${activity.image}" alt="${activity.title}">
+            <div>
+                <button class="join">Ich bin dabei</button>
+                <button class="decline">Ich bin raus</button>
+            </div>
+        `;
+        card.querySelector('.decline').addEventListener('click', () => {
+            activity.status = 'rejected';
+            renderCarousel();
+            renderRejected();
+        });
+        card.querySelector('.join').addEventListener('click', () => {
+            activity.status = 'accepted';
+            renderCarousel();
+        });
+        carousel.appendChild(card);
+    });
+}
+
+function renderRejected() {
+    const list = document.getElementById('rejectedList');
+    list.innerHTML = '';
+    activities.filter(a => a.status === 'rejected').forEach(activity => {
+        const mini = document.createElement('div');
+        mini.className = 'mini-card';
+        mini.innerHTML = `
+            <img src="${activity.image}" alt="${activity.title}">
+            <span>${activity.title}</span>
+        `;
+        mini.addEventListener('click', () => {
+            activity.status = 'none';
+            renderCarousel();
+            renderRejected();
+        });
+        list.appendChild(mini);
+    });
+}
+
+// Dropdown logic
+const dropdownButton = document.getElementById('dropdownButton');
+const dropdownList = document.getElementById('dropdownList');
+const rejectedMenu = document.getElementById('rejectedMenu');
+const rejectedSection = document.getElementById('rejectedSection');
+
+dropdownButton.addEventListener('click', () => {
+    dropdownList.classList.toggle('hidden');
+});
+
+rejectedMenu.addEventListener('click', () => {
+    rejectedSection.classList.toggle('hidden');
+    dropdownList.classList.add('hidden');
+});
+
+// Initial render
+renderCarousel();
+renderRejected();

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,82 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+header {
+    display: flex;
+    justify-content: flex-end;
+    padding: 10px;
+    background-color: #f5f5f5;
+}
+.profile-menu {
+    position: relative;
+}
+.profile-pic {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+}
+.dropdown button {
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+.dropdown ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    right: 0;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    width: 150px;
+}
+.dropdown ul li {
+    padding: 5px 10px;
+    cursor: pointer;
+}
+.dropdown ul li:hover {
+    background-color: #eee;
+}
+.hidden {
+    display: none;
+}
+#carousel {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    padding: 10px;
+}
+.card {
+    border: 1px solid #ccc;
+    padding: 10px;
+    width: 180px;
+    display: flex;
+    flex-direction: column;
+}
+.card img {
+    width: 100%;
+    height: 100px;
+    object-fit: cover;
+}
+.card button {
+    margin-top: auto;
+}
+#rejectedSection {
+    padding: 10px;
+}
+.mini-card {
+    border: 1px dashed #888;
+    margin: 5px;
+    padding: 5px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    cursor: pointer;
+}
+.mini-card img {
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- add minimal web UI
- show list of rejected activities under profile dropdown
- allow restoring rejected activities to the carousel
- document a quickstart for the example implementation

## Testing
- `python3 -m http.server 8001`

------
https://chatgpt.com/codex/tasks/task_e_686a525fe4548333ad0c4819da420cca