### PR TITLE
Implement activity detail modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,78 @@
+const activities = [
+  {
+    title: 'Wandern im Park',
+    date: '12. Mai 2024',
+    description: 'Wir treffen uns zum **Wandern** im Stadtpark. Alle Infos unter [CityPark](https://example.com).',
+    participants: [
+      {name: 'Anna', avatar: 'img/user1.svg'},
+      {name: 'Ben', avatar: 'img/user2.svg'}
+    ],
+    status: 'none'
+  },
+  {
+    title: 'Filmabend',
+    date: '20. Mai 2024',
+    description: 'Gemeinsamer Filmabend. Mehr unter [IMDB](https://example.com/movie).',
+    participants: [
+      {name: 'Clara', avatar: 'img/user3.svg'},
+      {name: 'David', avatar: 'img/user4.svg'}
+    ],
+    status: 'none'
+  }
+];
+
+function renderMarkdown(text) {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\[(.+?)\]\((http.+?)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
+    .replace(/\n/g, '<br>');
+}
+
+function openModal(index) {
+  const act = activities[index];
+  document.getElementById('detail-title').innerText = act.title;
+  document.getElementById('detail-date').innerText = act.date;
+  document.getElementById('detail-description').innerHTML = renderMarkdown(act.description);
+
+  const list = document.getElementById('detail-participants');
+  list.innerHTML = '';
+  act.participants.forEach(p => {
+    const li = document.createElement('li');
+    li.className = 'participant';
+    li.innerHTML = `<img src="${p.avatar}" alt="${p.name}"><span>${p.name}</span>`;
+    list.appendChild(li);
+  });
+
+  document.getElementById('toggle-status').checked = act.status === 'going';
+  document.getElementById('modal').classList.remove('hidden');
+}
+
+function closeModal() {
+  document.getElementById('modal').classList.add('hidden');
+}
+
+document.querySelectorAll('.activity-card').forEach(card => {
+  card.addEventListener('click', () => {
+    openModal(card.dataset.index);
+  });
+});
+
+document.getElementById('close-btn').addEventListener('click', closeModal);
+
+document.getElementById('modal').addEventListener('click', (e) => {
+  if (e.target.id === 'modal') {
+    closeModal();
+  }
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    closeModal();
+  }
+});
+
+document.getElementById('toggle-status').addEventListener('change', (e) => {
+  const title = document.getElementById('detail-title').innerText;
+  const act = activities.find(a => a.title === title);
+  act.status = e.target.checked ? 'going' : 'none';
+});

--- a/img/activity1.svg
+++ b/img/activity1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <rect width="200" height="100" fill="#8ecae6" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#023047">Wandern</text>
+</svg>

--- a/img/activity2.svg
+++ b/img/activity2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <rect width="200" height="100" fill="#ffb703" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#fb8500">Film</text>
+</svg>

--- a/img/user1.svg
+++ b/img/user1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+  <circle cx="25" cy="25" r="25" fill="#a8dadc" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#1d3557">A</text>
+</svg>

--- a/img/user2.svg
+++ b/img/user2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+  <circle cx="25" cy="25" r="25" fill="#ffafcc" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#590d22">B</text>
+</svg>

--- a/img/user3.svg
+++ b/img/user3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+  <circle cx="25" cy="25" r="25" fill="#bde0fe" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#023047">C</text>
+</svg>

--- a/img/user4.svg
+++ b/img/user4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+  <circle cx="25" cy="25" r="25" fill="#caffbf" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#006d77">D</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Activity Planner</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="carousel">
+    <div class="activity-card" data-index="0">
+      <h3>Wandern im Park</h3>
+      <small>12. Mai 2024</small>
+      <img src="img/activity1.svg" class="activity-image" alt="Wandern">
+    </div>
+    <div class="activity-card" data-index="1">
+      <h3>Filmabend</h3>
+      <small>20. Mai 2024</small>
+      <img src="img/activity2.svg" class="activity-image" alt="Filmabend">
+    </div>
+  </div>
+
+  <div id="modal" class="hidden">
+    <div class="modal-content">
+      <button id="close-btn" class="close">&times;</button>
+      <h2 id="detail-title"></h2>
+      <div id="detail-date" class="detail-date"></div>
+      <div id="detail-description" class="detail-description"></div>
+      <h3>Teilnehmer</h3>
+      <ul id="detail-participants" class="participants"></ul>
+      <div class="status-toggle">
+        <label>
+          <input type="checkbox" id="toggle-status"> Status ändern
+        </label>
+      </div>
+    </div>
+  </div>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,75 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+.carousel {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+}
+.activity-card {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  width: 200px;
+  text-align: center;
+  cursor: pointer;
+}
+.activity-card img {
+  width: 100%;
+  height: auto;
+}
+#modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.hidden {
+  display: none;
+}
+.modal-content {
+  background: white;
+  padding: 1rem;
+  border-radius: 5px;
+  max-width: 500px;
+  width: 90%;
+  max-height: 80%;
+  overflow-y: auto;
+  position: relative;
+}
+.close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+.participants {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.participant {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.participant img {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+.status-toggle {
+  margin-top: 1rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add sample index, JS and CSS
- implement modal to view activity details and toggle participation status
- include example SVG images for demo activities

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a526b07f48333a543f784ed2cdd2c