### PR TITLE
Implement Kalender-Reiter with ICS export

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ActivityPlanner Kalender</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Kalender</h1>
+    <div id="calendar-container">
+        <table id="calendar-table">
+            <thead>
+                <tr>
+                    <th>Datum</th>
+                    <th>Uhrzeit</th>
+                    <th>Titel</th>
+                    <th>Ort</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- Filled dynamically -->
+            </tbody>
+        </table>
+    </div>
+    <button id="export-ics">ICS exportieren</button>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/src/script.js
+++ b/src/script.js
@@ -1,0 +1,73 @@
+const events = [
+  {
+    title: 'Grillen im Park',
+    datetime: '2024-04-30T18:00',
+    description: 'Treffen im Stadtpark beim Haupteingang.',
+    rsvp: true,
+  },
+  {
+    title: 'Filmabend',
+    datetime: '2024-05-02T20:00',
+    description: 'Bei Alex zuhause, Kellerkino.',
+    rsvp: false,
+  },
+];
+
+function formatDate(dateStr) {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('de-DE');
+}
+
+function formatTime(dateStr) {
+  const date = new Date(dateStr);
+  return date.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
+
+function extractLocation(desc) {
+  const match = desc.match(/im ([A-Za-zÄÖÜäöüß\s]+)/);
+  return match ? match[1].trim() : '';
+}
+
+function populateTable() {
+  const tbody = document.querySelector('#calendar-table tbody');
+  events.forEach(event => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${formatDate(event.datetime)}</td>
+      <td>${formatTime(event.datetime)}</td>
+      <td>${event.title}</td>
+      <td>${extractLocation(event.description)}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function exportICS() {
+  const rsvpEvents = events.filter(e => e.rsvp);
+  let ics = 'BEGIN:VCALENDAR\nVERSION:2.0\n';
+  rsvpEvents.forEach(e => {
+    const dt = new Date(e.datetime);
+    const stamp = dt.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+    ics += 'BEGIN:VEVENT\n';
+    ics += `UID:${stamp}@activityplanner\n`;
+    ics += `DTSTAMP:${stamp}\n`;
+    ics += `DTSTART:${stamp}\n`;
+    ics += `SUMMARY:${e.title}\n`;
+    ics += `DESCRIPTION:${e.description}\n`;
+    ics += 'END:VEVENT\n';
+  });
+  ics += 'END:VCALENDAR';
+
+  const blob = new Blob([ics], { type: 'text/calendar' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'events.ics';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  populateTable();
+  document.getElementById('export-ics').addEventListener('click', exportICS);
+});

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,32 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+#calendar-container {
+    overflow-x: auto;
+}
+
+#calendar-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#calendar-table th,
+#calendar-table td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+@media (min-width: 700px) {
+    #calendar-container {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 20px;
+    }
+
+    #calendar-table {
+        width: auto;
+    }
+}


### PR DESCRIPTION
## Summary
- add simple calendar page showing upcoming activities
- include responsive layout for mobile and desktop
- support ICS export of own RSVPs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a5293ecd8833398bf0ed0472b9bfc