### PR TITLE
Implement UI demo with dark mode and swipe animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ Sicherheit	• Hoher Schutz vor Web-Angriffen (CSRF, XSS, SQL-Injection u. a.).
 ⸻
 
 Ergebnis: Eine fokussierte, private Planungsplattform mit maximaler Übersicht, blitzschnellen Reaktionen und minimalem Overhead – perfekt abgestimmt auf kleine Freundeskreise.
+
+## UI Demo
+Eine kleine Beispielseite befindet sich im Verzeichnis `public/`.
+Die Farbwahl wurde mit Blick auf ausreichende Kontraste (WCAG AA) getroffen.
+

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ActivityPlanner Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <button id="dark-mode-toggle" aria-label="Dark Mode">Dark Mode</button>
+  </header>
+  <main>
+    <div class="carousel">
+      <div class="card active">
+        <h2>Wandern</h2>
+        <p class="date">01.01.2025</p>
+        <img src="https://via.placeholder.com/300x200" alt="Wandern">
+        <div class="actions">
+          <button class="accept">Ich bin dabei</button>
+          <button class="decline">Ich bin raus</button>
+        </div>
+      </div>
+      <div class="card">
+        <h2>Kinoabend</h2>
+        <p class="date">05.01.2025</p>
+        <img src="https://via.placeholder.com/300x200" alt="Kinoabend">
+        <div class="actions">
+          <button class="accept">Ich bin dabei</button>
+          <button class="decline">Ich bin raus</button>
+        </div>
+      </div>
+      <div class="card">
+        <h2>Grillen</h2>
+        <p class="date">10.01.2025</p>
+        <img src="https://via.placeholder.com/300x200" alt="Grillen">
+        <div class="actions">
+          <button class="accept">Ich bin dabei</button>
+          <button class="decline">Ich bin raus</button>
+        </div>
+      </div>
+    </div>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,24 @@
+document.getElementById('dark-mode-toggle').addEventListener('click', () => {
+  const body = document.body;
+  body.classList.toggle('dark');
+  const btn = document.getElementById('dark-mode-toggle');
+  btn.textContent = body.classList.contains('dark') ? 'Light Mode' : 'Dark Mode';
+});
+
+function setupSwipe(card) {
+  const acceptBtn = card.querySelector('.accept');
+  const declineBtn = card.querySelector('.decline');
+  acceptBtn.addEventListener('click', () => swipe(card, 'right'));
+  declineBtn.addEventListener('click', () => swipe(card, 'left'));
+}
+
+function swipe(card, direction) {
+  card.style.transform = direction === 'right' ? 'translateX(100%)' : 'translateX(-100%)';
+  setTimeout(() => {
+    card.remove();
+    const next = document.querySelector('.card');
+    if (next) next.classList.add('active');
+  }, 250);
+}
+
+document.querySelectorAll('.card').forEach(setupSwipe);

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,95 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --positive-color: #157347;
+  --negative-color: #dc3545;
+  --card-bg: #ffffff;
+  --card-shadow: rgba(0, 0, 0, 0.1);
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: Arial, sans-serif;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+body.dark {
+  --bg-color: #121212;
+  --text-color: #ffffff;
+  --card-bg: #1e1e1e;
+  --card-shadow: rgba(0, 0, 0, 0.5);
+}
+
+header {
+  padding: 1rem;
+  text-align: right;
+}
+
+.carousel {
+  position: relative;
+  width: 320px;
+  margin: 0 auto;
+  flex-grow: 1;
+}
+
+.card {
+  background: var(--card-bg);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px var(--card-shadow);
+  transition: transform 250ms ease-out, box-shadow 250ms ease-out;
+  position: absolute;
+  width: 100%;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.card.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.card img {
+  width: 100%;
+  border-radius: 4px;
+  display: block;
+}
+
+.card .date {
+  font-size: 0.9rem;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.actions {
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
+.actions button {
+  padding: 0.5rem 1rem;
+  margin: 0 0.25rem;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+}
+
+.actions .accept {
+  background-color: var(--positive-color);
+}
+
+.actions .decline {
+  background-color: var(--negative-color);
+}
+
+@media(hover:hover) {
+  .card:hover {
+    box-shadow: 0 4px 8px var(--card-shadow);
+  }
+}


### PR DESCRIPTION
## Summary
- add basic demo UI with three cards
- implement card swipe animation with 250ms ease-out
- enable hover shadows on desktop
- add dark mode toggle and color scheme that passes WCAG AA
- document demo location in README

## Testing
- `pip install --quiet wcag-contrast-ratio`
- manual contrast ratio calculations to verify WCAG AA

------
https://chatgpt.com/codex/tasks/task_e_686a52c947888333bee1c0408144054e