### PR TITLE
Implement login and session management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,4 +27,9 @@ There are currently no tests or code style rules defined.
   rejection of unsupported types.
 * Test image data is embedded as a Base64 string to avoid storing binary files
   in the repository.
+* Implemented `/login` route with session management. Session cookie is
+  configured as secure, HttpOnly and SameSite=Lax with a 10-minute inactivity
+  timeout and rolling refresh. Failed logins are tracked in memory and after
+  three wrong attempts the account is blocked for five minutes. Added Jest tests
+  verifying secure cookies, rate limiting and session refresh.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Projektdokument – Private Planungs-Web-App für Freundeskreise",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --runInBand",
     "dev": "nodemon index.js",
     "start": "node index.js"
   },

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,0 +1,77 @@
+const request = require('supertest');
+const fs = require('fs').promises;
+const path = require('path');
+const app = require('../index');
+
+const DATA_FILE = path.join(__dirname, '..', 'data', 'users.json');
+
+describe('login and session management', () => {
+  const agent = request.agent(app);
+  beforeAll(async () => {
+    await fs.writeFile(DATA_FILE, '[]');
+    // register user
+    const getRes = await agent.get('/register').set('X-Forwarded-Proto', 'https');
+    const csrf = /name="_csrf" value="([^"]+)"/.exec(getRes.text)[1];
+    const pngBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/P+BKywAAAABJRU5ErkJggg==';
+    await agent
+      .post('/register')
+      .set('X-Forwarded-Proto', 'https')
+      .field('_csrf', csrf)
+      .field('username', 'loginTester')
+      .field('password', 'strongpassword')
+      .attach('avatar', Buffer.from(pngBase64, 'base64'), {
+        filename: 'test.png',
+        contentType: 'image/png',
+      });
+  });
+
+  it('sets secure session cookie on login', async () => {
+    const getRes = await agent.get('/login').set('X-Forwarded-Proto', 'https');
+    const csrf = /name="_csrf" value="([^"]+)"/.exec(getRes.text)[1];
+    const res = await agent
+      .post('/login')
+      .set('X-Forwarded-Proto', 'https')
+      .send(`username=loginTester&password=strongpassword&_csrf=${csrf}`);
+
+    expect(res.statusCode).toBe(200);
+    const cookie = res.headers['set-cookie'][0];
+    expect(cookie).toMatch(/HttpOnly/);
+    expect(cookie).toMatch(/SameSite=Lax/);
+  });
+
+  it('rate limits after three failed attempts', async () => {
+    const getRes = await agent.get('/login').set('X-Forwarded-Proto', 'https');
+    const csrf = /name="_csrf" value="([^"]+)"/.exec(getRes.text)[1];
+
+    for (let i = 0; i < 3; i++) {
+      const res = await agent
+        .post('/login')
+        .set('X-Forwarded-Proto', 'https')
+        .send(`username=loginTester&password=wrong&_csrf=${csrf}`);
+      expect(res.statusCode).toBe(401);
+    }
+
+    const res4 = await agent
+      .post('/login')
+      .set('X-Forwarded-Proto', 'https')
+      .send(`username=loginTester&password=wrong&_csrf=${csrf}`);
+    expect(res4.statusCode).toBe(429);
+  });
+
+  it('refreshes cookie on activity', async () => {
+    const getRes = await agent.get('/login').set('X-Forwarded-Proto', 'https');
+    const csrf = /name="_csrf" value="([^"]+)"/.exec(getRes.text)[1];
+    const loginRes = await agent
+      .post('/login')
+      .set('X-Forwarded-Proto', 'https')
+      .send(`username=loginTester&password=strongpassword&_csrf=${csrf}`);
+    const firstCookie = loginRes.headers['set-cookie'][0];
+
+    const res = await agent
+      .get('/')
+      .set('X-Forwarded-Proto', 'https');
+    const newCookie = res.headers['set-cookie'][0];
+    expect(newCookie).toBeDefined();
+  });
+});

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -13,7 +13,7 @@ describe('registration with profile image', () => {
   });
 
   it('accepts jpeg/png upload and saves profile', async () => {
-    const getRes = await agent.get('/register');
+    const getRes = await agent.get('/register').set('X-Forwarded-Proto', 'https');
     const match = /name="_csrf" value="([^"]+)"/.exec(getRes.text);
     const csrf = match[1];
 
@@ -21,6 +21,7 @@ describe('registration with profile image', () => {
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/P+BKywAAAABJRU5ErkJggg==';
     const res = await agent
       .post('/register')
+      .set('X-Forwarded-Proto', 'https')
       .field('_csrf', csrf)
       .field('username', 'tester')
       .field('password', 'strongpassword')
@@ -37,12 +38,13 @@ describe('registration with profile image', () => {
   });
 
   it('rejects unsupported file type', async () => {
-    const getRes = await agent.get('/register');
+    const getRes = await agent.get('/register').set('X-Forwarded-Proto', 'https');
     const match = /name="_csrf" value="([^"]+)"/.exec(getRes.text);
     const csrf = match[1];
 
     const res = await agent
       .post('/register')
+      .set('X-Forwarded-Proto', 'https')
       .field('_csrf', csrf)
       .field('username', 'tester2')
       .field('password', 'strongpassword')


### PR DESCRIPTION
## Summary
- configure express-session with secure cookie defaults and rolling 10-minute maxAge
- add `/login` route with CSRF protection and rate limiting
- update registration and login tests for secure proxy header
- add new login test suite
- run Jest tests in-band
- document changes in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a5b619f54833389dbd686006aecf1