### PR TITLE
Implement basic activity carousel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,4 @@ There are currently no tests or code style rules defined.
   verifying secure cookies, rate limiting and session refresh.
 
 * Implemented responsive main layout served from `/`. Added global toolbar with "Kommt her" button and ready indicator. Palette variables exposed via `/static/styles.css`. Jest tests ensure toolbar and color palette are served.
+* Added basic activities carousel: `/activities` API returns upcoming events sorted by date. Frontend fetches these and displays swipe-able cards with join/decline buttons. Sample data stored in `data/activities.json`. Jest test checks sorting.

--- a/data/activities.json
+++ b/data/activities.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "a1",
+    "title": "Grillen am See",
+    "date": "2025-04-10T12:00:00Z",
+    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAA6ElEQVR4nO3RAQkAMAzAsPlXNllXMQ4lUVDoLGnzO4BbBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMHb9gDP2N2uCjq3EwAAAABJRU5ErkJggg==",
+    "participants": 2
+  },
+  {
+    "id": "a2",
+    "title": "Kinoabend",
+    "date": "2025-04-20T18:00:00Z",
+    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABDElEQVR4nO3RAQkAQAyAwPUPYKbFWornQYQLIDgLWa/5XpB9qcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3G7QDGiONktgUu4AAAAABJRU5ErkJggg==",
+    "participants": 3
+  },
+  {
+    "id": "a3",
+    "title": "Wandern",
+    "date": "2025-05-05T10:00:00Z",
+    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABC0lEQVR4nO3RAQkAQAyAwPUPYKbF+hTPQIQLIDgswWvOC8JPDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuD8lj42QOVhCKAAAAAElFTkSuQmCC",
+    "participants": 1
+  }
+]

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const DATA_FILE = path.join(__dirname, 'data', 'users.json');
 const ASSET_DIR = path.join(__dirname, 'user-assets');
+const ACTIVITIES_FILE = path.join(__dirname, 'data', 'activities.json');
 
 fs.mkdir(ASSET_DIR, { recursive: true }).catch(() => {});
 
@@ -28,6 +29,15 @@ async function loadUsers() {
 
 async function saveUsers(users) {
   await fs.writeFile(DATA_FILE, JSON.stringify(users, null, 2));
+}
+
+async function loadActivities() {
+  try {
+    const data = await fs.readFile(ACTIVITIES_FILE, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return [];
+  }
 }
 
 app.use(express.urlencoded({ extended: false }));
@@ -163,6 +173,12 @@ app.post('/login', csurf(), async (req, res) => {
   loginAttempts[username] = { count: 0, blockedUntil: 0 };
   req.session.userId = user.id;
   res.send('Login erfolgreich');
+});
+
+app.get('/activities', async (req, res) => {
+  const activities = await loadActivities();
+  activities.sort((a, b) => new Date(a.date) - new Date(b.date));
+  res.json(activities);
 });
 
 

--- a/public/app.js
+++ b/public/app.js
@@ -3,3 +3,44 @@ const indicator = document.getElementById('ready-indicator');
 indicator.addEventListener('click', () => {
   indicator.classList.toggle('ready');
 });
+
+async function initCarousel() {
+  const res = await fetch('/activities');
+  const activities = await res.json();
+  if (!activities.length) return;
+
+  let index = 0;
+  const card = document.getElementById('activity-card');
+  const title = card.querySelector('.title');
+  const dateEl = card.querySelector('.date');
+  const img = card.querySelector('.image');
+  const partDiv = card.querySelector('.participants');
+  const joinBtn = card.querySelector('.join');
+  const declineBtn = card.querySelector('.decline');
+
+  function show(i) {
+    const act = activities[i];
+    title.textContent = act.title;
+    const d = new Date(act.date);
+    dateEl.textContent = d.toLocaleDateString('de-DE');
+    img.src = act.image;
+    partDiv.innerHTML = '';
+    for (let p = 0; p < act.participants; p++) {
+      const span = document.createElement('span');
+      span.className = 'participant-icon';
+      partDiv.appendChild(span);
+    }
+  }
+
+  function next() {
+    index = (index + 1) % activities.length;
+    show(index);
+  }
+
+  joinBtn.addEventListener('click', next);
+  declineBtn.addEventListener('click', next);
+
+  show(index);
+}
+
+window.addEventListener('DOMContentLoaded', initCarousel);

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,18 @@
     </div>
   </div>
   <div class="main">
-    <p>Willkommen bei ActivityPlanner</p>
+    <div id="carousel" class="carousel">
+      <div class="card" id="activity-card">
+        <h2 class="title"></h2>
+        <p class="date"></p>
+        <img class="image" src="" alt="Bild" />
+        <div class="participants"></div>
+        <div class="buttons">
+          <button class="join">Ich bin dabei</button>
+          <button class="decline">Ich bin raus</button>
+        </div>
+      </div>
+    </div>
   </div>
   <script src="/static/app.js"></script>
 </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -57,3 +57,60 @@ body {
   justify-content: center;
   align-items: center;
 }
+
+.carousel {
+  width: 90%;
+  max-width: 400px;
+}
+
+.card {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.card img {
+  width: 100%;
+  aspect-ratio: 16/9;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.participants {
+  margin: 0.5rem 0;
+}
+
+.participant-icon {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #bbb;
+  margin-right: 4px;
+}
+
+.buttons {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 0.5rem;
+}
+
+.join {
+  background: var(--positive);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.decline {
+  background: var(--negative);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/tests/carousel.test.js
+++ b/tests/carousel.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+const fs = require('fs').promises;
+const path = require('path');
+const app = require('../index');
+
+const ACT_FILE = path.join(__dirname, '..', 'data', 'activities.json');
+
+describe('activities carousel', () => {
+  beforeAll(async () => {
+    const data = [
+      { id: 'b', title: 'B', date: '2025-05-01T00:00:00Z', image: '', participants: 0 },
+      { id: 'a', title: 'A', date: '2025-04-01T00:00:00Z', image: '', participants: 0 }
+    ];
+    await fs.writeFile(ACT_FILE, JSON.stringify(data));
+  });
+
+  it('returns activities sorted by date ascending', async () => {
+    const res = await request(app).get('/activities').set('X-Forwarded-Proto', 'https');
+    expect(res.statusCode).toBe(200);
+    expect(res.body[0].id).toBe('a');
+    expect(res.body[1].id).toBe('b');
+  });
+});


### PR DESCRIPTION
## Summary
- add `/activities` API endpoint
- implement frontend carousel that cycles through activities
- create sample activities dataset with base64 images
- style carousel cards and buttons
- test activity sorting
- document changes for future agents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6164c7bc8333b4fd91d93d9876e5