### PR TITLE
Implement Story 7 join/decline with realtime updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,4 @@ There are currently no tests or code style rules defined.
 
 * Implemented responsive main layout served from `/`. Added global toolbar with "Kommt her" button and ready indicator. Palette variables exposed via `/static/styles.css`. Jest tests ensure toolbar and color palette are served.
 * Added basic activities carousel: `/activities` API returns upcoming events sorted by date. Frontend fetches these and displays swipe-able cards with join/decline buttons. Sample data stored in `data/activities.json`. Jest test checks sorting.
+* Implemented join/decline backend with WebSocket broadcasting. Clients update participant icons in real time and activity creators receive browser notifications. Added routes `/activities/:id/join` and `/activities/:id/decline`, WebSocket server using `ws`, and front-end logic with Notification API. Jest tests cover joining and declining activities.

--- a/data/activities.json
+++ b/data/activities.json
@@ -3,21 +3,24 @@
     "id": "a1",
     "title": "Grillen am See",
     "date": "2025-04-10T12:00:00Z",
-    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAA6ElEQVR4nO3RAQkAMAzAsPlXNllXMQ4lUVDoLGnzO4BbBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMHb9gDP2N2uCjq3EwAAAABJRU5ErkJggg==",
-    "participants": 2
+    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAA6ElEQVR4nO3RAQkAMAzAsPlXNllXMQ4lUVDoLGnzO4BbBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMFxBscZHGdwnMHb9gDP2N2uCjq3EwAAAABJRU5ErkJggg==",
+    "creator": "u1",
+    "participants": []
   },
   {
     "id": "a2",
     "title": "Kinoabend",
     "date": "2025-04-20T18:00:00Z",
-    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABDElEQVR4nO3RAQkAQAyAwPUPYKbFWornQYQLIDgLWa/5XpB9qcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3G7QDGiONktgUu4AAAAABJRU5ErkJggg==",
-    "participants": 3
+    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABDElEQVR4nO3RAQkAQAyAwPUPYKbFWornQYQLIDgLWa/5XpB9qcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3GrcG4NRi3BuPWYNwajFuDcWswbg3G7QDGiONktgUu4AAAAABJRU5ErkJggg==",
+    "creator": "u2",
+    "participants": []
   },
   {
     "id": "a3",
     "title": "Wandern",
     "date": "2025-05-05T10:00:00Z",
-    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABC0lEQVR4nO3RAQkAQAyAwPUPYKbF+hTPQIQLIDgswWvOC8JPDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuD8lj42QOVhCKAAAAAElFTkSuQmCC",
-    "participants": 1
+    "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABaCAIAAACwpMoFAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABC0lEQVR4nO3RAQkAQAyAwPUPYKbF+hTPQIQLIDgswWvOC8JPDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuDcatwbg1GLcG49Zg3BqMW4NxazBuD8lj42QOVhCKAAAAAElFTkSuQmCC",
+    "creator": "u3",
+    "participants": []
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "express-session": "^1.18.1",
         "multer": "^2.0.1",
         "sharp": "^0.34.2",
-        "validator": "^13.15.15"
+        "validator": "^13.15.15",
+        "ws": "^8.18.3"
       },
       "devDependencies": {
         "jest": "^30.0.4",
@@ -6394,6 +6395,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "express-session": "^1.18.1",
     "multer": "^2.0.1",
     "sharp": "^0.34.2",
-    "validator": "^13.15.15"
+    "validator": "^13.15.15",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "jest": "^30.0.4",

--- a/public/index.html
+++ b/public/index.html
@@ -29,5 +29,9 @@
     </div>
   </div>
   <script src="/static/app.js"></script>
+  <script>
+    window.USER_ID = '{{USER_ID}}';
+    window.USERNAME = '{{USERNAME}}';
+  </script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -87,7 +87,7 @@ body {
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #bbb;
+  object-fit: cover;
   margin-right: 4px;
 }
 

--- a/tests/carousel.test.js
+++ b/tests/carousel.test.js
@@ -8,8 +8,8 @@ const ACT_FILE = path.join(__dirname, '..', 'data', 'activities.json');
 describe('activities carousel', () => {
   beforeAll(async () => {
     const data = [
-      { id: 'b', title: 'B', date: '2025-05-01T00:00:00Z', image: '', participants: 0 },
-      { id: 'a', title: 'A', date: '2025-04-01T00:00:00Z', image: '', participants: 0 }
+      { id: 'b', title: 'B', date: '2025-05-01T00:00:00Z', image: '', participants: [] },
+      { id: 'a', title: 'A', date: '2025-04-01T00:00:00Z', image: '', participants: [] }
     ];
     await fs.writeFile(ACT_FILE, JSON.stringify(data));
   });

--- a/tests/participation.test.js
+++ b/tests/participation.test.js
@@ -1,0 +1,65 @@
+const request = require('supertest');
+const fs = require('fs').promises;
+const path = require('path');
+const app = require('../index');
+
+const USERS_FILE = path.join(__dirname, '..', 'data', 'users.json');
+const ACT_FILE = path.join(__dirname, '..', 'data', 'activities.json');
+const ASSET_DIR = path.join(__dirname, '..', 'user-assets');
+
+describe('join and decline activities', () => {
+  const agent = request.agent(app);
+  let userId;
+
+  beforeAll(async () => {
+    await fs.rm(ASSET_DIR, { recursive: true, force: true });
+    await fs.writeFile(USERS_FILE, '[]');
+    const activities = [
+      { id: 'x1', title: 'Test', date: '2025-01-01T00:00:00Z', image: '', creator: 'u1', participants: [] }
+    ];
+    await fs.writeFile(ACT_FILE, JSON.stringify(activities));
+
+    const getRes = await agent.get('/register').set('X-Forwarded-Proto', 'https');
+    const csrf = /name="_csrf" value="([^"]+)"/.exec(getRes.text)[1];
+    const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/P+BKywAAAABJRU5ErkJggg==';
+    await agent
+      .post('/register')
+      .set('X-Forwarded-Proto', 'https')
+      .field('_csrf', csrf)
+      .field('username', 'joiner')
+      .field('password', 'strongpassword')
+      .attach('avatar', Buffer.from(pngBase64, 'base64'), {
+        filename: 'test.png',
+        contentType: 'image/png'
+      });
+    const users = JSON.parse(await fs.readFile(USERS_FILE));
+    userId = users[0].id;
+
+    const logRes = await agent.get('/login').set('X-Forwarded-Proto', 'https');
+    const lcsrf = /name="_csrf" value="([^"]+)"/.exec(logRes.text)[1];
+    await agent
+      .post('/login')
+      .set('X-Forwarded-Proto', 'https')
+      .send(`username=joiner&password=strongpassword&_csrf=${lcsrf}`);
+  });
+
+  it('adds user to participants on join', async () => {
+    const res = await agent.post('/activities/x1/join').set('X-Forwarded-Proto', 'https');
+    expect(res.statusCode).toBe(200);
+    const activities = JSON.parse(await fs.readFile(ACT_FILE));
+    expect(activities[0].participants).toContain(userId);
+  });
+
+  it('removes user from participants on decline', async () => {
+    const res = await agent.post('/activities/x1/decline').set('X-Forwarded-Proto', 'https');
+    expect(res.statusCode).toBe(200);
+    const activities = JSON.parse(await fs.readFile(ACT_FILE));
+    expect(activities[0].participants).not.toContain(userId);
+  });
+
+  it('requires login to join', async () => {
+    const other = request(app);
+    const res = await other.post('/activities/x1/join').set('X-Forwarded-Proto', 'https');
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- support participants as arrays and add creator field to activities
- add WebSocket server with join/decline API endpoints
- embed user data in layout and update client-side carousel
- broadcast events and show notifications
- update styles for participant icons
- document changes in `AGENTS.md`
- add tests for joining/declining activities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6435bee48333a7b36411f78bac5f