### PR TITLE
Add image compression and caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,9 @@ There are currently no tests or code style rules defined.
   sanitized using the `validator` package. Future agents should keep these
   security measures intact when extending authentication or user management.
 * Added profile picture upload during registration using `multer` and `sharp`.
-  Images are resized to 512x512px, saved under `user-assets/<userid>/profile.jpg`
-  and served statically. Tests with Jest/Supertest verify file handling and
-  rejection of unsupported types.
+  Images are resized to 512x512px and stored under `user-assets/<userid>/profile.jpg`
+  or `profile.webp`. They are served via `/assets/<id>/profile`. Tests with
+  Jest/Supertest verify file handling and rejection of unsupported types.
 * Test image data is embedded as a Base64 string to avoid storing binary files
   in the repository.
 * Implemented `/login` route with session management. Session cookie is
@@ -41,4 +41,5 @@ There are currently no tests or code style rules defined.
 * Added "Kommt her" quick action. Clicking the toolbar button opens a dialog for title and description. Submitted actions are inserted as first carousel card with glowing green border, broadcast via WebSocket and expire after six hours. Expired items move to `/past`. Jest tests verify creation and expiry logic.
 * Implemented ready status bar. `/ready` toggles a user's two-hour ready flag and broadcasts current ready users via WebSocket. Frontend displays their icons next to "Kommt her". Tests cover toggling and expiry.
 * Added past activities view at `/history`. Dropdown link "Vergangene Aktivitäten" in the profile menu opens a table listing completed events chronologically with a ✔/✖ column showing user's participation. Pagination shows 20 items per page via `?page=` parameter. Older activities are automatically marked as past when their date is in the past.
-* Implemented calendar view `/calendar` listing accepted upcoming activities with date, time, title and parsed location. Includes `/calendar.ics` export of these events. Added responsive layout styles and menu link "Kalender". Jest tests verify listing order, location extraction and ICS generation.
+  * Implemented calendar view `/calendar` listing accepted upcoming activities with date, time, title and parsed location. Includes `/calendar.ics` export of these events. Added responsive layout styles and menu link "Kalender". Jest tests verify listing order, location extraction and ICS generation.
+* Optimized uploaded images: JPEGs are compressed to 80% quality and PNGs converted to WebP. Files are served via `/assets/<id>/profile` with long-term caching headers and a cache-first service worker caches static assets. Tests cover image conversion and cache headers.

--- a/public/app.js
+++ b/public/app.js
@@ -6,7 +6,7 @@ function updateReadyBar(list) {
   readyBar.innerHTML = '';
   list.forEach((u) => {
     const img = document.createElement('img');
-    img.src = `/${u.id}/profile.jpg`;
+    img.src = `/assets/${u.id}/profile`;
     img.className = 'ready-icon';
     readyBar.appendChild(img);
   });
@@ -59,7 +59,7 @@ async function initCarousel() {
     (act.participants || []).forEach((id) => {
       const imgEl = document.createElement('img');
       imgEl.className = 'participant-icon';
-      imgEl.src = `/${id}/profile.jpg`;
+      imgEl.src = `/assets/${id}/profile`;
       partDiv.appendChild(imgEl);
     });
   }
@@ -70,7 +70,7 @@ async function initCarousel() {
       const d = document.createElement('div');
       d.className = 'detail-participant';
       const imgEl = document.createElement('img');
-      imgEl.src = `/${p.id}/profile.jpg`;
+      imgEl.src = `/assets/${p.id}/profile`;
       const span = document.createElement('span');
       span.textContent = p.username;
       d.appendChild(imgEl);

--- a/public/index.html
+++ b/public/index.html
@@ -57,6 +57,9 @@
     window.USER_ID = '{{USER_ID}}';
     window.USERNAME = '{{USERNAME}}';
     window.READY = {{READY}};
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/static/sw.js');
+    }
   </script>
 </body>
 </html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,20 @@
+self.addEventListener('install', (e) => {
+  e.waitUntil(
+    caches.open('static-v1').then((cache) => cache.addAll(['/static/styles.css', '/static/app.js']))
+  );
+});
+
+self.addEventListener('fetch', (e) => {
+  if (e.request.url.includes('/assets/') || e.request.url.includes('/static/')) {
+    e.respondWith(
+      caches.open('static-v1').then((cache) =>
+        cache.match(e.request).then((resp) =>
+          resp || fetch(e.request).then((response) => {
+            cache.put(e.request, response.clone());
+            return response;
+          })
+        )
+      )
+    );
+  }
+});

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -1,0 +1,14 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('static caching', () => {
+  it('serves service worker with cache header', async () => {
+    const res = await request(app)
+      .get('/static/sw.js')
+      .set('X-Forwarded-Proto', 'https');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['cache-control']).toMatch(/max-age=3600/);
+    expect(res.text).toContain('caches.open');
+  });
+});
+

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -31,10 +31,17 @@ describe('registration with profile image', () => {
       });
 
     expect(res.statusCode).toBe(200);
-    const users = JSON.parse(await fs.readFile(path.join(__dirname, '..', 'data', 'users.json')));
+    const users = JSON.parse(
+      await fs.readFile(path.join(__dirname, '..', 'data', 'users.json'))
+    );
     expect(users[0]).toHaveProperty('id');
-    const imgPath = path.join(ASSET_DIR, users[0].id, 'profile.jpg');
+    const imgPath = path.join(ASSET_DIR, users[0].id, 'profile.webp');
     await fs.access(imgPath);
+
+    const imgRes = await agent
+      .get(`/assets/${users[0].id}/profile`)
+      .set('X-Forwarded-Proto', 'https');
+    expect(imgRes.headers['cache-control']).toMatch(/max-age=31536000/);
   });
 
   it('rejects unsupported file type', async () => {


### PR DESCRIPTION
## Summary
- compress uploaded images: JPEG quality 80%, PNG converted to WebP
- serve profile images via `/assets/:id/profile` with long-term caching
- add service worker with cache‑first strategy
- cache static assets using Cache-Control headers
- document latest changes in AGENTS instructions
- test caching headers and image conversion

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a6fbbd6d883338eacb1dd1c41a266