### PR TITLE
Improve login/register flow with styled pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,17 +248,10 @@ app.get("/", async (req, res) => {
 
 
 
-app.get('/register', csurf(), (req, res) => {
-  const form = `
-    <form action="/register" method="POST" enctype="multipart/form-data">
-      <input type="hidden" name="_csrf" value="${req.csrfToken()}">
-      <div><label>Nutzername: <input name="username" required></label></div>
-      <div><label>Passwort: <input type="password" name="password" required></label></div>
-      <div><label>Profilbild: <input type="file" name="avatar" accept="image/jpeg,image/png" required></label></div>
-      <button type="submit">Registrieren</button>
-    </form>
-  `;
-  res.send(form);
+app.get('/register', csurf(), async (req, res) => {
+  let html = await fs.readFile(path.join(__dirname, 'public', 'register.html'), 'utf8');
+  html = html.replace('{{CSRF}}', req.csrfToken());
+  res.type('html').send(html);
 });
 
 app.post('/register', upload.single('avatar'), csurf(), async (req, res) => {
@@ -310,23 +303,15 @@ app.post('/register', upload.single('avatar'), csurf(), async (req, res) => {
   } else {
     await imgSharp.jpeg({ quality: 80 }).toFile(path.join(userDir, 'profile.jpg'));
   }
-
-  const img = `<img src="/assets/${id}/profile" style="border-radius:50%;width:128px;height:128px;" />`;
-  res.send(`Registrierung erfolgreich.<br>${img}`);
+  res.redirect(303, '/login');
 });
 
 const loginAttempts = {};
 
-app.get('/login', csurf(), (req, res) => {
-  const form = `
-    <form action="/login" method="POST">
-      <input type="hidden" name="_csrf" value="${req.csrfToken()}">
-      <div><label>Nutzername: <input name="username" required></label></div>
-      <div><label>Passwort: <input type="password" name="password" required></label></div>
-      <button type="submit">Login</button>
-    </form>
-  `;
-  res.send(form);
+app.get('/login', csurf(), async (req, res) => {
+  let html = await fs.readFile(path.join(__dirname, 'public', 'login.html'), 'utf8');
+  html = html.replace('{{CSRF}}', req.csrfToken());
+  res.type('html').send(html);
 });
 
 app.post('/login', csurf(), async (req, res) => {
@@ -354,7 +339,7 @@ app.post('/login', csurf(), async (req, res) => {
 
   loginAttempts[username] = { count: 0, blockedUntil: 0 };
   req.session.userId = user.id;
-  res.send('Login erfolgreich');
+  res.redirect(303, '/');
 });
 
 app.get('/vapid-key', (req, res) => {

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/static/styles.css">
+  <title>Login</title>
+</head>
+<body>
+  <form action="/login" method="POST">
+    <input type="hidden" name="_csrf" value="{{CSRF}}">
+    <div><label>Nutzername: <input name="username" required></label></div>
+    <div><label>Passwort: <input type="password" name="password" required></label></div>
+    <button type="submit">Login</button>
+  </form>
+  <p><a href="/register">Registrieren</a></p>
+</body>
+</html>

--- a/public/register.html
+++ b/public/register.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/static/styles.css">
+  <title>Registrieren</title>
+</head>
+<body>
+  <form action="/register" method="POST" enctype="multipart/form-data">
+    <input type="hidden" name="_csrf" value="{{CSRF}}">
+    <div><label>Nutzername: <input name="username" required></label></div>
+    <div><label>Passwort: <input type="password" name="password" required></label></div>
+    <div><label>Profilbild: <input type="file" name="avatar" accept="image/jpeg,image/png" required></label></div>
+    <button type="submit">Registrieren</button>
+  </form>
+  <p><a href="/login">Login</a></p>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -21,6 +21,14 @@ body {
   background: var(--bg);
   color: var(--text);
 }
+a {
+  color: var(--positive);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
 .toolbar {
   display: flex;
   justify-content: space-between;

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -34,7 +34,7 @@ describe('login and session management', () => {
       .set('X-Forwarded-Proto', 'https')
       .send(`username=loginTester&password=strongpassword&_csrf=${csrf}`);
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(303);
     const cookie = res.headers['set-cookie'][0];
     expect(cookie).toMatch(/HttpOnly/);
     expect(cookie).toMatch(/SameSite=Lax/);

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -30,7 +30,7 @@ describe('registration with profile image', () => {
         contentType: 'image/png',
       });
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(303);
     const users = JSON.parse(
       await fs.readFile(path.join(__dirname, '..', 'data', 'users.json'))
     );


### PR DESCRIPTION
## Summary
- add consistent link styling
- serve `login.html` and `register.html` templates
- redirect after successful login and registration
- update tests for new status codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a935f1a84833386c0d0c6f52d55d9