### PR TITLE
Fix profile menu display

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,9 +12,10 @@
     <button id="dark-toggle" aria-label="Dark Mode">🌓</button>
     <div id="ready-bar" class="ready-bar"></div>
     <div class="profile">
-      <img id="profile-pic" src="{{PROFILE_SRC}}" alt="Profil" />
       <details class="menu">
-        <summary></summary>
+        <summary>
+          <img id="profile-pic" src="{{PROFILE_SRC}}" alt="Profil" />
+        </summary>
         <a href="/rejected">Abgelehnt</a>
         <a href="/history">Vergangene Aktivitäten</a>
         <a href="/calendar">Kalender</a>


### PR DESCRIPTION
## Summary
- make profile dropdown clickable by moving profile image into menu summary

## Testing
- `CHROME_PATH=/usr/local/bin/chrome-fake npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a984e89c88333b88d491d79bbcffe